### PR TITLE
Load options when injecting js

### DIFF
--- a/wp-minify.php
+++ b/wp-minify.php
@@ -890,6 +890,7 @@ class WPMinify {
 
 	function inject_js($content, $js_locations, $js_locations_footer) {
 		if (count($js_locations) > 0) {
+			$wpm_options = get_option($this->name);
 			// build minify URLS
 			$js_tags = '';
 			$minify_urls = $this->build_minify_urls($js_locations, '.js');


### PR DESCRIPTION
Options wasn't previously loaded when injecting javascripts, even though it's referenced later in the function. 
Async and javascript-position (header/footer) options wasn't working because of this